### PR TITLE
Add Ruby Test Switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A curated list of delightful Atom packages and resources. For more awesomeness, 
  - [Project Plus](#project-plus)
  - [Code Peek](#code-peek)
  - [Rails Open Rspec](#rails-open-rspec)
+ - [Ruby Test Switcher](#ruby-test-switcher)
  - [Sort lines](#sort-lines)
  - [Sync Settings](#sync-settings)
  - [Terminal-Plus](#terminal-plus)
@@ -169,6 +170,9 @@ JavaScript, and much more in Atom.
 > Open rspec file by current file in rails project.
 
 ![](https://raw.githubusercontent.com/harada4atsushi/rails-open-rspec/master/rails-open-rspec.gif)
+
+#### [Ruby Test Switcher](https://atom.io/packages/ruby-test-switcher)
+> Switch between Ruby source code and test files with a keystroke. It supports RSpec, minitest and test-unit, both in Rails and non-Rails projects.
 
 #### [Sort Lines](https://atom.io/packages/sort-lines)
 > Sorts your lines. Never gets tired.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ A curated list of delightful Atom packages and resources. For more awesomeness, 
  - [Pigments](#pigments)
  - [Project Plus](#project-plus)
  - [Code Peek](#code-peek)
- - [Rails Open Rspec](#rails-open-rspec)
  - [Ruby Test Switcher](#ruby-test-switcher)
  - [Sort lines](#sort-lines)
  - [Sync Settings](#sync-settings)
@@ -165,11 +164,6 @@ JavaScript, and much more in Atom.
 > Quickly peek and edit functions in separate files from the context of your current editor.
 
 ![Code Peek Demo](https://github.com/DFreds/code-peek-atom/blob/master/code-peek.gif?raw=true)
-
-#### [Rails Open Rspec](https://atom.io/packages/rails-open-rspec)
-> Open rspec file by current file in rails project.
-
-![](https://raw.githubusercontent.com/harada4atsushi/rails-open-rspec/master/rails-open-rspec.gif)
 
 #### [Ruby Test Switcher](https://atom.io/packages/ruby-test-switcher)
 > Switch between Ruby source code and test files with a keystroke. It supports RSpec, minitest and test-unit, both in Rails and non-Rails projects.


### PR DESCRIPTION
_ruby-test-switcher_ is an _Atom_ package to switch between _Ruby_ source code and test files with a single keystroke.

It supports _RSpec_, _minitest_ and _test-unit_, both in _Rails_ and non-_Rails_ projects.
